### PR TITLE
fix: instrumentRequest的this指针指向错误

### DIFF
--- a/src/integrations/breadcrumbs.js
+++ b/src/integrations/breadcrumbs.js
@@ -136,7 +136,7 @@ export class Breadcrumbs {
     }
 
     fill(this.ctx, 'request', (originalRequest) => {
-      return function(requestOptions = {}) {
+      return (requestOptions = {}) => {
         let method = requestOptions.method ? requestOptions.method.toUpperCase() : 'GET';
         let url = requestOptions.url;
 


### PR DESCRIPTION
此处的`this.ctx`没有指向`Breadcrumbs`实例，改成箭头函数

https://github.com/alexayan/sentry-mina/blob/0485a8369ee1d4bb4a47d36c6f796ecb21d7347e/src/integrations/breadcrumbs.js#L192